### PR TITLE
Remove "Long-Press gesture suppressed" log

### DIFF
--- a/ios/Plugin/SuppressLongpressGesturePlugin.swift
+++ b/ios/Plugin/SuppressLongpressGesturePlugin.swift
@@ -56,6 +56,5 @@ public class SuppressLongpressGesturePlugin: CAPPlugin {
     }
 
     @objc func handleLongpressGesture() {
-        print("Long-press gesture suppressed")
     }
 }


### PR DESCRIPTION
I feel like this log is not really needed here, it just clutters the log output. What do you think?